### PR TITLE
Refactor component position assignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,9 +101,9 @@ If you need absolute URLs for your images remember to set up your asset host in 
 
 ```ruby
 Rails.application.configure do
-  ...
+  #...
   config.action_controller.asset_host = 'http://your.host.com'
-  ...
+  #...
 end
 ```
 
@@ -820,7 +820,7 @@ Let's say you have a component which depends on another components and you want 
 @component_B = @structure.components.detect{|c| c.slug == 'component_B'}
 ```
 
-```ruby
+```erb
 # view
 <%= simple_form_for @structure, html: { class: 'some-form-class' } do |f| %>
   <%= f.simple_fields_for :components, @component_A do |A| %>
@@ -918,14 +918,14 @@ cd spec/dummy
 rm -rf db/migrate
 rails db:drop
 rails db:create
-RAILS_ENV=test rails db:migrate
+rails db:test:prepare
 cd ../.. 
 ```
 
 Here the oneliner: 
 
 ```bash
-cd spec/dummy && rm -rf db/migrate && rails db:drop && rails db:create && RAILS_ENV=test rails db:migrate && cd ../.. 
+cd spec/dummy && rm -rf db/migrate && rails db:drop && rails db:create && rails db:test:prepare && cd ../.. 
 ```
 
 If Binda migration have been updated then your `schema.rb` is outdated and will generate false failing tests. In this case you need to run following command to refresh your database configuration:
@@ -936,6 +936,7 @@ rm -r db/schema.rb
 rails db:drop
 rails db:create
 rails generate binda:install
+rails db:test:prepare
 rm -rf db/migrate
 rm -rf config/initializers/devise_backup_*.rb
 cd ../..
@@ -944,7 +945,7 @@ cd ../..
 Here the oneliner:
 
 ```bash
-cd spec/dummy && rm -r db/schema.rb && rails db:drop && rails db:create && rails generate binda:install && rm -rf db/migrate && rm -rf config/initializers/devise_backup_*.rb && cd ../..
+cd spec/dummy && rm -r db/schema.rb && rails db:drop && rails db:create && rails generate binda:install && rails db:test:prepare && rm -rf db/migrate && rm -rf config/initializers/devise_backup_*.rb && cd ../..
 ```
 
 If in the future you need to clean your dummy app code, simply run:

--- a/app/models/binda/component.rb
+++ b/app/models/binda/component.rb
@@ -41,7 +41,7 @@ module Binda
 
 		# Friendly id preference on slug generation
 		#
-		# Method inherited from friendly id 
+		# Method inherited from friendly id
 		# @see https://github.com/norman/friendly_id/issues/436
 		def should_generate_new_friendly_id?
 			slug.blank?
@@ -72,12 +72,12 @@ module Binda
 				end
 		end
 
-		private 
+		private
 
 			def set_default_position
 				Component
 					.where(structure_id: self.structure_id)
-					.each{|component| component.increment(:position).save!}
+					.update_all('position = position + 1')
 			end
 
 	end

--- a/db/migrate/1_create_binda_tables.rb
+++ b/db/migrate/1_create_binda_tables.rb
@@ -14,7 +14,7 @@ class CreateBindaTables < ActiveRecord::Migration[5.0]
       t.string           :slug
       t.index            :slug, unique: true
       t.string           :publish_state
-      t.integer          :position
+      t.integer          :position, default: 0
       t.belongs_to       :structure
       t.timestamps
     end
@@ -121,7 +121,7 @@ class CreateBindaTables < ActiveRecord::Migration[5.0]
       t.belongs_to :selection, index: true
       t.timestamps
     end
-    
+
     create_table :binda_selections do |t|
       t.belongs_to       :field_setting
       t.references       :fieldable, polymorphic: true, index: true


### PR DESCRIPTION
Fixing one of the performance bottolenecks listed in issue BindaCMS/binda#211. Now it's 40% faster!!

A database schema update is necessary:

1. Create a migration from terminal
```
rails generate migration updateComponentPositionDefault
```

2. Add the following line between `def change ... end` in `db/migration/0000_update_component_position_default.rb` (you probably don't have the `0000` sequence)
```
class UpdateComponentPositionDefault < ActiveRecord::Migration[5.2]
  def change
    change_column :binda_components, :position, :integer, default: 0
  end
end
```

3. Run the migration in your terminal
```
rails db:migrate
```
